### PR TITLE
Directly use column name in `unnest_wider()` calls

### DIFF
--- a/R/espn_wbb_data.R
+++ b/R/espn_wbb_data.R
@@ -45,12 +45,12 @@ espn_wbb_game_all <- function(game_id){
       raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
       
       plays <- plays %>%
-        tidyr::unnest_wider(unlist(.data$participants))
+        tidyr::unnest_wider(.data$participants)
       suppressWarnings(
         aths <- plays %>%
           dplyr::group_by(.data$id) %>%
           dplyr::select(.data$id, .data$athlete.id) %>%
-          tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = ".")
+          tidyr::unnest_wider(.data$athlete.id,names_sep = ".")
       )
       names(aths)<-c("play.id","athlete.id.1","athlete.id.2")
       plays_df <- dplyr::bind_cols(plays, aths) %>%
@@ -230,12 +230,12 @@ espn_wbb_pbp <- function(game_id){
       raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
       #---- Play-by-Play ------
       plays <- raw_play_df %>%
-        tidyr::unnest_wider(unlist(.data$participants))
+        tidyr::unnest_wider(.data$participants)
       suppressWarnings(
         aths <- plays %>%
           dplyr::group_by(.data$id) %>%
           dplyr::select(.data$id, .data$athlete.id) %>%
-          tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = ".")
+          tidyr::unnest_wider(.data$athlete.id,names_sep = ".")
       )
       names(aths)<-c("play.id","athlete.id.1","athlete.id.2")
       plays_df <- dplyr::bind_cols(plays, aths) %>%
@@ -514,7 +514,7 @@ espn_wbb_teams <- function(){
       
       leagues <- jsonlite::fromJSON(resp)[["sports"]][["leagues"]][[1]][['teams']][[1]][['team']] %>%
         dplyr::group_by(.data$id) %>%
-        tidyr::unnest_wider(unlist(.data$logos, use.names=FALSE),names_sep = "_") %>%
+        tidyr::unnest_wider(.data$logos,names_sep = "_") %>%
         tidyr::unnest_wider(.data$logos_href,names_sep = "_") %>%
         dplyr::select(-.data$logos_width,-.data$logos_height,
                       -.data$logos_alt, -.data$logos_rel) %>%

--- a/R/espn_wnba_data.R
+++ b/R/espn_wnba_data.R
@@ -43,12 +43,12 @@ espn_wnba_game_all <- function(game_id){
       
       
       plays <- raw_play_df[["plays"]] %>%
-        tidyr::unnest_wider(unlist(.data$participants))
+        tidyr::unnest_wider(.data$participants)
       suppressWarnings(
         aths <- plays %>%
           dplyr::group_by(.data$id) %>%
           dplyr::select(.data$id, .data$athlete.id) %>%
-          tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = "_")
+          tidyr::unnest_wider(.data$athlete.id,names_sep = "_")
       )
       names(aths)<-c("play.id","athlete.id.1","athlete.id.2","athlete.id.3")
       plays_df <- dplyr::bind_cols(plays, aths) %>%
@@ -207,12 +207,12 @@ espn_wnba_pbp <- function(game_id){
   raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
   #---- Play-by-Play ------
   plays <- raw_play_df[["plays"]] %>%
-    tidyr::unnest_wider(unlist(.data$participants, use.names=FALSE))
+    tidyr::unnest_wider(.data$participants)
   suppressWarnings(
     aths <- plays %>%
       dplyr::group_by(.data$id) %>%
       dplyr::select(.data$id, .data$athlete.id) %>%
-      tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = ".")
+      tidyr::unnest_wider(.data$athlete.id,names_sep = ".")
   )
   names(aths)<-c("play.id","athlete.id.1","athlete.id.2","athlete.id.3")
   plays_df <- dplyr::bind_cols(plays, aths) %>%
@@ -421,7 +421,7 @@ espn_wnba_teams <- function(){
   ## game_id
   leagues <- jsonlite::fromJSON(resp)[["sports"]][["leagues"]][[1]][['teams']][[1]][['team']] %>%
     dplyr::group_by(.data$id) %>%
-    tidyr::unnest_wider(unlist(.data$logos, use.names=FALSE),names_sep = "_") %>%
+    tidyr::unnest_wider(.data$logos,names_sep = "_") %>%
     tidyr::unnest_wider(.data$logos_href,names_sep = "_") %>%
     dplyr::select(-.data$logos_width,-.data$logos_height,
                   -.data$logos_alt, -.data$logos_rel) %>%


### PR DESCRIPTION
Hi, I am working on improving the rectangling functions in tidyr, and your package came up in revdep checks, see https://github.com/tidyverse/tidyr/pull/1200.

In particular, there are many usages of `unlist(.data$col)` where really you just needed to use `.data$col`. It is unfortunate that the previous behavior worked at all, but it is considered off-label and we don't support it.

This PR fixes those issues. It does not require dev tidyr, so this one could be merged and sent to CRAN without needing the new version of tidyr. 