### PR TITLE
Expect a `"notes"` column in the scoreboard functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     rlang (>= 0.4.0),
     rvest (>= 1.0.0),
     stringr (>= 1.3.0),
-    tidyr (>= 1.0.0),
+    tidyr (>= 1.1.4.9000),
     usethis (>= 1.6.0)
 Suggests: 
     crayon (>= 1.3.4),
@@ -46,3 +46,5 @@ Suggests:
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
+Remotes:
+    tidyverse/tidyr#1200

--- a/tests/testthat/test-espn_wbb_scoreboard.R
+++ b/tests/testthat/test-espn_wbb_scoreboard.R
@@ -6,7 +6,7 @@ cols <- c("matchup", "matchup_short", "season", "type", "slug", "game_id",
           "home_team_color", "home_score", "home_win", "home_record", "away_team_name", 
           "away_team_logo", "away_team_abbreviation", "away_team_id", "away_team_location", 
           "away_team_full_name", "away_team_color", "away_score", "away_win", 
-          "away_record", "status_name","broadcast_market","broadcast_name", "start_date")
+          "away_record", "notes", "status_name","broadcast_market","broadcast_name", "start_date")
 
 test_that("ESPN - WBB Scoreboard", {
   skip_on_cran()

--- a/tests/testthat/test-espn_wnba_scoreboard.R
+++ b/tests/testthat/test-espn_wnba_scoreboard.R
@@ -5,7 +5,7 @@ cols <- c("matchup", "matchup_short", "season", "type", "slug",
           "home_team_full_name", "home_team_color", "home_score", "home_win", "home_record", 
           "away_team_name", "away_team_logo", "away_team_abbreviation", "away_team_id", 
           "away_team_location", "away_team_full_name", "away_team_color", "away_score", 
-          "away_win", "away_record", 
+          "away_win", "away_record", "notes",
           "status_name","broadcast_market","broadcast_name", "start_date")
 
 test_that("ESPN - WNBA Scoreboard", {


### PR DESCRIPTION
Followup to #14 

The other change that comes with https://github.com/tidyverse/tidyr/pull/1200 is that now list-columns that contained completely empty cells are correctly retained. When you downloaded scoreboard data, there was a `$notes` element that always held `list()`. That column is now retained in the dev version of tidyr, so a few tests need to be updated.

Luckily, since those tests aren't run on CRAN, you won't get flagged by CRAN when we release tidyr.

Ideally, you'd merge #14 for us and send a new version of your package to CRAN, then we'd release tidyr, then you could merge in this PR and require the new version of tidyr.

This PR won't pass GitHub Action checks, because it needs #14.