### PR TITLE
update internal `load_wbb_games()` and `load_wnba_games()` url

### DIFF
--- a/R/load_wbb.R
+++ b/R/load_wbb.R
@@ -255,7 +255,7 @@ load_wbb_schedule <- function(seasons = most_recent_wbb_season(), ...,
 
 # load games file
 load_wbb_games <- function(){
-  .url <- "https://raw.githubusercontent.com/sportsdataverse/wehoop-data/main/wbb/wbb_games_in_data_repo.csv"
+  .url <- "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_schedules/wbb_games_in_data_repo.csv"
   dat <- csv_from_url(.url)
   # close(con)
   return(dat)

--- a/R/load_wnba.R
+++ b/R/load_wnba.R
@@ -242,7 +242,7 @@ load_wnba_schedule <- function(seasons = most_recent_wnba_season(), ...,
 
 # load games file
 load_wnba_games <- function(){
-  .url <- "https://raw.githubusercontent.com/sportsdataverse/wehoop-data/main/wnba/wnba_games_in_data_repo.csv"
+  .url <- "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_schedules/wnba_games_in_data_repo.csv"
   con <- url(.url)
   dat <- utils::read.csv(con)
   # close(con)


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updates the data source URLs in `load_wbb_games()` and `load_wnba_games()` functions to use the sportsdataverse-data releases instead of the deprecated wehoop-data repository.

- Changed the URL in `R/load_wnba.R` from `wehoop-data/main/wnba/wnba_games_in_data_repo.csv` to `sportsdataverse-data/releases/download/espn_wnba_schedules/wnba_games_in_data_repo.csv` to access more recent game data.
- Changed the URL in `R/load_wbb.R` from `wehoop-data/main/wbb/wbb_games_in_data_repo.csv` to `sportsdataverse-data/releases/download/espn_womens_college_basketball_schedules/wbb_games_in_data_repo.csv` to access more recent game data.
- These changes fix issue #41 and enable the `update_wnba_db()` function to run with the most recent games, with data now available through 2024-10-20 for WNBA and 2025-04-06 for WBB.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

Hi @saiemgilani @hutchngo,

This looks like it might have been missed in [the 2.0 update](https://github.com/sportsdataverse/wehoop/releases/tag/v2.0.0), but this PR updates the csv url for `load_wbb_games()` and `load_wnba_games()`. They use the data from `sportsdataverse/releases` instead of `sportsdataverse/wehoop-data/`. 

This closes https://github.com/sportsdataverse/wehoop/issues/41 and allows the `update_wnba_db()` to run with the most recent games. 

```r
> load_wnba_games()[['game_date']] |> max()
[1] "2024-10-20"
> load_wbb_games()[, max(game_date)]
trying URL 'https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_schedules/wbb_games_in_data_repo.csv'
Content type 'application/octet-stream' length 50338078 bytes (48.0 MB)
==================================================
downloaded 48.0 MB

[1] "2025-04-06"
```

### Tests

This is my first time contributing, but 19 tests failed. I couldn't find anything related to these functions specifically or the update db functions. The failed tests looked mostly like schema changes from different api calls. I wanted to check with you all for guidance before making changes to the codebase outside of this limited scope.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated data source URLs for women's college basketball and WNBA games to improve data reliability. No changes to functionality or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->