### PR TITLE
Removes Conferences Subgroups (Minor fix)

### DIFF
--- a/R/espn_wbb_data.R
+++ b/R/espn_wbb_data.R
@@ -1011,7 +1011,6 @@ espn_wbb_conferences <- function(){
         httr::content(as = "text", encoding = "UTF-8")
       
       conferences <- jsonlite::fromJSON(resp)[["conferences"]] %>%
-        dplyr::select(-"subGroups") %>%
         janitor::clean_names() %>%
         dplyr::filter(!(.data$group_id %in% c(0,50))) %>%
         dplyr::mutate(


### PR DESCRIPTION
_Note: duplicate of https://github.com/sportsdataverse/hoopR/pull/165_

There was one faulty line of code:

`dplyr::select(-"subGroups") %>%`

that was causing the entire `espn_wbb_conferences()` function and subsequently the conferences portion of the `espn_wbb_teams()` function to break. It was not needed, given the GET response, and removing it caused the function to work as intended. As the title implies, it is a very small change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conference data now retains the subGroups column that was previously removed during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->