### PR TITLE
Change conference data retrieval process

### DIFF
--- a/R/espn_wbb_data.R
+++ b/R/espn_wbb_data.R
@@ -1004,14 +1004,10 @@ espn_wbb_conferences <- function(){
       
       res <- httr::RETRY("GET", play_base_url)
       
-      # Check the result
-      check_status(res)
-      
       resp <- res %>%
         httr::content(as = "text", encoding = "UTF-8")
       
       conferences <- jsonlite::fromJSON(resp)[["conferences"]] %>%
-        dplyr::select(-"subGroups") %>%
         janitor::clean_names() %>%
         dplyr::filter(!(.data$group_id %in% c(0,50))) %>%
         dplyr::mutate(


### PR DESCRIPTION
Removed status check and subGroups selection from conference data processing.

ALSO: There is no data on Mercyhurst or West Georgia in the teams data, this might affect the conferences / teams functions later down the line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WBB conference data now includes additional grouping information.

* **Bug Fixes**
  * Improved error handling for WBB conference data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->