### PR TITLE
chore(tools): add WNBA Stats API probe scripts under tools/probes/

### DIFF
--- a/tools/probes/README.md
+++ b/tools/probes/README.md
@@ -1,0 +1,64 @@
+# `tools/probes/` — WNBA Stats API regression-check toolkit
+
+Manual probe scripts for diagnosing upstream API health when a wrapper
+starts misbehaving. Each script targets a specific failure mode that has
+historically surfaced in the wehoop / hoopR issue trackers — endpoint
+retirement, payload shape changes, query-string sensitivity, client
+fingerprinting, or data-collection gaps.
+
+These are **diagnostic tools, not tests**. They print to stdout, use real
+network, and aren't run by `devtools::check()` (the whole `tools/` tree is
+in `.Rbuildignore`).
+
+## When to reach for which probe
+
+| If users report... | Run |
+| --- | --- |
+| `wnba_<fn>()` errors with `Connection was reset` or returns HTML | [`probe_schedule_endpoints.R`](probe_schedule_endpoints.R) for schedule-class endpoints; [`probe_cdn_payload.R`](probe_cdn_payload.R) to verify a CDN replacement is parser-compatible |
+| `wnba_<fn>()` returns the wrong league's data | [`probe_known_broken.R`](probe_known_broken.R) — confirm against the live endpoint with explicit `league_id="10"` |
+| `wnba_<fn>()` returns 200 + HTML instead of JSON | [`probe_param_order_sensitivity.R`](probe_param_order_sensitivity.R) — same param values in alphabetical vs `LeagueID`-first order |
+| Mac/Linux user reports a wrapper "doesn't work" but it works on Windows | [`probe_known_broken.R`](probe_known_broken.R) from the reporter's environment — disentangle endpoint-dead from client-fingerprinting |
+| hoopR adds a new `lifecycle::deprecate_stop(with = "nba_X")` redirect | [`probe_hoopr_redirect_targets.R`](probe_hoopr_redirect_targets.R) — verify `wnba_X` exists *and* returns data |
+| Considering deprecating a hustle wrapper | [`probe_hustle_deprecated.R`](probe_hustle_deprecated.R) — sweep all 6 hustle endpoints; [`probe_hustle_boxscore_deep.R`](probe_hustle_boxscore_deep.R) for the boxscore-style one specifically |
+| Considering adopting an NBA-only endpoint for WNBA use | [`probe_nba_endpoints_with_wnba_params.R`](probe_nba_endpoints_with_wnba_params.R) — most tracking endpoints return empty for WNBA, but a few populate |
+| Quick smoke test after editing a wrapper | [`verify_wrapper_changes.R`](verify_wrapper_changes.R) — update the call list, run, eyeball the shape summary |
+
+## Common conventions
+
+All probes follow the same shape:
+
+```r
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+# Update for current season before running.
+game_id <- "1022600021"  # 2026-05-15 CON vs LVA
+season  <- "2025-26"
+```
+
+Prefer the package's own `wehoop:::request_with_proxy()` +
+`wehoop:::wnba_stats_map_result_sets()` over bare `httr2` calls when
+hitting `stats.wnba.com` — the package helper sends the WNBA-specific
+headers (`Origin`, `Referer`, `x-nba-stats-origin`, `x-nba-stats-token`)
+that the upstream Cloudflare gate looks for. Bare `httr2` calls
+frequently get `Connection was reset` from the same machine where the
+package-helper version succeeds.
+
+For CDN endpoints (`cdn.wnba.com`, `cdn.nba.com`) use bare `httr2` with
+browser-ish headers — no `x-nba-stats-*` tokens needed.
+
+## Updating probes between seasons
+
+Each probe declares `game_id` and `season` constants at the top. After
+the WNBA season changes, update these once per file:
+
+- `game_id` — any recently-finalized game id from the current season
+  (e.g. via `wnba_scoreboardv3(game_date = format(Sys.Date()-1, "%Y-%m-%d"), league_id = "10")`)
+- `season` — `"YYYY-YY"` for WNBA Stats API (`"2025-26"` for the 2026 season)
+
+## Adding a new probe
+
+Mirror the existing files: header doc-block with the *what* and *why*,
+followed by a self-contained R script that prints to stdout. Add an entry
+to the table above. Keep them runnable in isolation (`Rscript`-friendly,
+no shared state).

--- a/tools/probes/probe_cdn_payload.R
+++ b/tools/probes/probe_cdn_payload.R
@@ -1,0 +1,84 @@
+## probe_cdn_payload.R
+## -------------------
+## Walks the first gameDates[].games[] entry of the CDN schedule JSON for
+## both leagues and prints every leaf key + a sample value. Used to verify
+## that a candidate CDN endpoint is parser-compatible with the existing
+## `wnba_schedule()` / `nba_schedule()` `tidyr::unnest("games") |>
+## unnest("awayTeam"|"homeTeam")` pipeline before migrating a wrapper.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_cdn_payload.R
+options(warn = 1)
+suppressPackageStartupMessages({
+  library(httr2)
+  library(jsonlite)
+})
+
+ua <- "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+fetch <- function(url) {
+  resp <- httr2::request(url) |>
+    httr2::req_headers(
+      "User-Agent" = ua,
+      "Accept"     = "application/json"
+    ) |>
+    httr2::req_timeout(60) |>
+    httr2::req_retry(max_tries = 3, backoff = function(i) 2 + i,
+                     is_transient = function(r) TRUE) |>
+    httr2::req_perform()
+  list(status = httr2::resp_status(resp),
+       body = httr2::resp_body_string(resp))
+}
+
+show_game_shape <- function(label, url) {
+  cat("\n=== ", label, " ===\n", sep = "")
+  r <- tryCatch(fetch(url), error = function(e) { cat("ERROR:", conditionMessage(e), "\n"); NULL })
+  if (is.null(r)) return(invisible(NULL))
+  cat("status:", r$status, "  bytes:", nchar(r$body), "\n")
+  if (r$status >= 400) return(invisible(NULL))
+  d <- jsonlite::fromJSON(r$body, simplifyVector = FALSE)
+  ls <- d$leagueSchedule
+  cat("seasonYear:", ls$seasonYear, "  leagueId:", ls$leagueId,
+      "  gameDates count:", length(ls$gameDates), "\n")
+  if (!length(ls$gameDates)) return(invisible(NULL))
+  gd1 <- ls$gameDates[[1]]
+  cat("first gameDate keys:", paste(names(gd1), collapse=", "), "\n")
+  cat("first gameDate.gameDate value:", gd1$gameDate, "\n")
+  if (length(gd1$games) == 0) {
+    cat("first gameDate has 0 games; trying gameDates[[2]]\n")
+    gd1 <- ls$gameDates[[2]]
+  }
+  g1 <- gd1$games[[1]]
+  cat("\nfirst game keys (", length(g1), "):\n  ", paste(names(g1), collapse="\n  "), "\n", sep="")
+  cat("\nawayTeam sub-keys:\n  ", paste(names(g1$awayTeam), collapse=", "), "\n", sep="")
+  cat("\nhomeTeam sub-keys:\n  ", paste(names(g1$homeTeam), collapse=", "), "\n", sep="")
+  cat("\nfirst game sample (selected scalars):\n")
+  scalars <- c("gameId", "gameCode", "gameStatus", "gameStatusText",
+               "gameDateEst", "gameTimeEst", "gameDateTimeEst",
+               "weekNumber", "weekName", "seriesGameNumber", "seriesText",
+               "arenaName", "arenaCity", "arenaState", "ifNecessary",
+               "postponedStatus", "branchLink", "gameSubtype")
+  for (k in scalars) {
+    v <- g1[[k]]
+    if (!is.null(v)) cat("  ", k, " = ", as.character(v), "\n", sep="")
+  }
+  cat("  awayTeam.teamId/tricode = ", g1$awayTeam$teamId, " / ",
+      g1$awayTeam$teamTricode, "\n", sep="")
+  cat("  homeTeam.teamId/tricode = ", g1$homeTeam$teamId, " / ",
+      g1$homeTeam$teamTricode, "\n", sep="")
+  invisible(d)
+}
+
+show_game_shape("WNBA CDN scheduleLeagueV2.json",
+                "https://cdn.wnba.com/static/json/staticData/scheduleLeagueV2.json")
+
+show_game_shape("WNBA CDN scheduleLeagueV2_1.json",
+                "https://cdn.wnba.com/static/json/staticData/scheduleLeagueV2_1.json")
+
+show_game_shape("NBA  CDN scheduleLeagueV2.json",
+                "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2.json")
+
+show_game_shape("NBA  CDN scheduleLeagueV2_1.json",
+                "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2_1.json")
+
+cat("\nDone.\n")

--- a/tools/probes/probe_hoopr_redirect_targets.R
+++ b/tools/probes/probe_hoopr_redirect_targets.R
@@ -1,0 +1,140 @@
+## probe_hoopr_redirect_targets.R
+## ------------------------------
+## Live-probe every endpoint that is either (a) a hoopR `with =` deprecation
+## redirect target, or (b) deprecated in wehoop but with an NBA twin that is
+## still active in hoopR. Goal: figure out which endpoints actually have WNBA
+## data right now, so we know which wehoop deprecations to revisit and which
+## hoopR-recommended replacements actually work for WNBA users.
+##
+## Bypasses each deprecated wehoop wrapper's `lifecycle::deprecate_stop()`
+## shim by calling `request_with_proxy()` directly with the right endpoint +
+## params. Use this any time you're considering deprecating a wrapper, or
+## any time hoopR adds a new `with = ` redirect.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_hoopr_redirect_targets.R
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+probe <- function(label, endpoint, params, parse = c("map", "raw")) {
+  parse <- match.arg(parse)
+  cat("\n=== ", label, " (", endpoint, ") ===\n", sep = "")
+  url <- paste0("https://stats.wnba.com/stats/", endpoint)
+  resp <- tryCatch(
+    wehoop:::request_with_proxy(url = url, params = params),
+    error = function(e) { cat("  HTTP/parse ERR:", conditionMessage(e), "\n"); NULL }
+  )
+  if (is.null(resp)) return(invisible(NULL))
+  if (parse == "map") {
+    sets <- tryCatch(wehoop:::wnba_stats_map_result_sets(resp),
+                     error = function(e) { cat("  MAP ERR:", conditionMessage(e), "\n"); NULL })
+    if (is.null(sets)) return(invisible(NULL))
+    for (nm in names(sets)) {
+      d <- sets[[nm]]
+      cat(sprintf("  [%s]  rows=%d  cols=%d\n", nm, nrow(d), ncol(d)))
+      if (nrow(d) > 0 && ncol(d) > 0) {
+        cat("    cols: ", paste(head(colnames(d), 10), collapse=", "),
+            if (ncol(d) > 10) ", ..." else "", "\n", sep = "")
+      }
+    }
+  } else {
+    cat("  raw top-level: ", paste(names(resp), collapse=", "), "\n", sep="")
+  }
+  Sys.sleep(3)
+  invisible(resp)
+}
+
+game_id     <- "1022600021"  # CON vs LVA, 2026-05-15
+season_yy   <- "2025-26"
+season_int  <- 2025
+
+## ============================================================
+## (1) wehoop-deprecated, hoopR still uses as redirect target
+## ============================================================
+
+## playerprofilev2 — hoopR redirects nba_playernextngames → nba_playerprofilev2.
+## wehoop deprecated wnba_playerprofilev2(). Test if endpoint returns data.
+probe("playerprofilev2 (A'ja Wilson)", "playerprofilev2",
+      list(LeagueID = "10", PerMode = "PerGame", PlayerID = "1628932"))
+
+## videodetailsasset — hoopR redirects nba_videodetails → nba_videodetailsasset.
+## wehoop deprecated wnba_videodetailsasset(). Game-keyed.
+probe("videodetailsasset (WNBA game)", "videodetailsasset",
+      list(
+        LeagueID = "10", Season = season_yy, SeasonType = "Regular Season",
+        TeamID = 0, PlayerID = 0, GameID = game_id,
+        ContextMeasure = "FGM", PlayerPosition = "", GameSegment = "",
+        Period = 0, LastNGames = 0, ClutchTime = "", AheadBehind = "",
+        PointDiff = "", RangeType = 0, StartPeriod = 1, EndPeriod = 10,
+        StartRange = 0, EndRange = 28800, ContextFilter = "",
+        OppPlayerID = 0, RookieYear = "", Outcome = "", Location = "",
+        Month = 0, SeasonSegment = "", DateFrom = "", DateTo = "",
+        OpponentTeamID = 0, VsConference = "", VsDivision = ""
+      ))
+
+## ============================================================
+## (2) Active redirect targets — confirm WNBA actually populates
+## ============================================================
+
+probe("leagueleaders (2025-26 PerGame PTS)", "leagueleaders",
+      list(LeagueID = "10", PerMode = "PerGame", StatCategory = "PTS",
+           Season = season_yy, SeasonType = "Regular Season",
+           Scope = "S", ActiveFlag = "No"))
+
+probe("franchiseleaders (Aces)", "franchiseleaders",
+      list(LeagueID = "10", TeamID = "1611661319"))
+
+probe("teamgamelogs (Aces, 2025-26)", "teamgamelogs",
+      list(LeagueID = "10", TeamID = "1611661319",
+           Season = season_yy, SeasonType = "Regular Season",
+           DateFrom = "", DateTo = "", Location = "", Outcome = "",
+           SeasonSegment = "", VsConference = "", VsDivision = "",
+           GameSegment = "", Period = 0, LastNGames = 0,
+           MeasureType = "Base", PerMode = "Totals",
+           PlusMinus = "N", PaceAdjust = "N", Rank = "N",
+           Conference = "", Division = ""))
+
+probe("playercareerbycollegerollup", "playercareerbycollegerollup",
+      list(LeagueID = "10", PerMode = "Totals", Season = season_yy,
+           SeasonType = "Regular Season", College = ""))
+
+probe("leaguedashplayerbiostats", "leaguedashplayerbiostats",
+      list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+           SeasonType = "Regular Season",
+           College = "", Conference = "", Country = "",
+           DateFrom = "", DateTo = "", Division = "",
+           DraftPick = "", DraftYear = "",
+           GameScope = "", GameSegment = "",
+           Height = "", LastNGames = 0, Location = "",
+           Month = 0, OpponentTeamID = 0, Outcome = "",
+           PORound = "", PlayerExperience = "", PlayerPosition = "",
+           SeasonSegment = "", ShotClockRange = "",
+           StarterBench = "", TeamID = 0,
+           VsConference = "", VsDivision = "", Weight = ""))
+
+## ============================================================
+## (3) wehoop-only deprecations worth re-checking
+## ============================================================
+
+probe("teaminfocommon (Aces 2025-26)", "teaminfocommon",
+      list(LeagueID = "10", SeasonType = "Regular Season",
+           TeamID = "1611661319", season_nullable = ""))
+
+probe("teamyearbyyearstats (Aces)", "teamyearbyyearstats",
+      list(LeagueID = "10", PerMode = "Totals",
+           SeasonType = "Regular Season", TeamID = "1611661319"))
+
+probe("leaguelineupviz", "leaguelineupviz",
+      list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+           SeasonType = "Regular Season", GroupQuantity = 5,
+           MinutesMin = 0, DateFrom = "", DateTo = "", Division = "",
+           Conference = "", GameSegment = "", LastNGames = 0,
+           Location = "", MeasureType = "Base", Month = 0,
+           OpponentTeamID = 0, Outcome = "", PORound = "",
+           PaceAdjust = "N", Period = 0, PlusMinus = "N", Rank = "N",
+           SeasonSegment = "", ShotClockRange = "",
+           TeamID = 0, VsConference = "", VsDivision = ""))
+
+cat("\nDone.\n")

--- a/tools/probes/probe_hustle_boxscore_deep.R
+++ b/tools/probes/probe_hustle_boxscore_deep.R
@@ -1,0 +1,55 @@
+## probe_hustle_boxscore_deep.R
+## ----------------------------
+## Hits the `hustlestatsboxscore` endpoint via `request_with_proxy` +
+## `wnba_stats_map_result_sets` for a handful of recent + historical WNBA
+## game_ids and reports the per-resultSet row counts. Used to answer the
+## question "does the upstream API publish populated PlayerStats / TeamStats
+## tables for WNBA games, or just the `HustleStatsAvailable` flag?".
+##
+## When the deprecation case for `wnba_hustlestatsboxscore()` was first
+## written, all three resultSets came back empty. This probe is the
+## periodic re-check.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_hustle_boxscore_deep.R
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+url <- "https://stats.wnba.com/stats/hustlestatsboxscore"
+
+dump <- function(game_id) {
+  cat("\n=== game_id =", game_id, "===\n")
+  resp <- tryCatch(
+    wehoop:::request_with_proxy(url = url, params = list(GameID = wehoop:::pad_id(game_id))),
+    error = function(e) { cat("  HTTP ERROR:", conditionMessage(e), "\n"); NULL }
+  )
+  if (is.null(resp)) return(invisible(NULL))
+  sets <- tryCatch(
+    wehoop:::wnba_stats_map_result_sets(resp),
+    error = function(e) { cat("  MAP ERROR:", conditionMessage(e), "\n"); NULL }
+  )
+  if (is.null(sets)) return(invisible(NULL))
+  cat("  result-set names: ", paste(names(sets), collapse=" | "), "\n", sep="")
+  for (nm in names(sets)) {
+    d <- sets[[nm]]
+    cat(sprintf("  [%s]  nrow=%d  ncol=%d\n", nm, nrow(d), ncol(d)))
+    cat("    cols: ", paste(colnames(d), collapse=", "), "\n", sep="")
+    if (nrow(d) > 0) {
+      cat("    head:\n")
+      print(utils::head(d, 4))
+    }
+  }
+  Sys.sleep(5)
+}
+
+for (gid in c("1022600021", "1022600024", "1022600022")) dump(gid)
+
+## Historical check
+cat("\n--- historical check (2024 season end) ---\n")
+sb <- tryCatch(wnba_scoreboardv3(game_date = "2024-09-25", league_id = "10"),
+               error = function(e) NULL)
+if (!is.null(sb) && nrow(sb) > 0) {
+  dump(sb$game_id[1])
+}
+
+cat("\nDone.\n")

--- a/tools/probes/probe_hustle_deprecated.R
+++ b/tools/probes/probe_hustle_deprecated.R
@@ -1,0 +1,111 @@
+## probe_hustle_deprecated.R
+## --------------------------
+## Probe whether the 6 hustle-family endpoints that are currently deprecated
+## via `lifecycle::deprecate_stop()` in wehoop have started returning data
+## again. Bypasses each wrapper's deprecation shim by calling
+## `request_with_proxy()` directly with WNBA `LeagueID = "10"` and a current
+## game_id. Reports per-endpoint result-set names + row/col counts.
+##
+## Covers: leaguehustlestatsplayer, leaguehustlestatsteam,
+## leaguehustlestatsplayerleaders, leaguehustlestatsteamleaders,
+## hustlestatsboxscore, boxscorehustlev2.
+##
+## Update `game_id` and `season` constants for the current season before
+## running.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_hustle_deprecated.R
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+# 2026 WNBA finals from 2026-05-15
+game_id <- "1022600021"  # CON vs LVA
+season  <- "2025-26"     # WNBA seasons render as "YYYY-YY"
+
+# Helper: hit an endpoint via the package's request_with_proxy and report shape
+probe <- function(label, endpoint, params, peek_cols = TRUE) {
+  cat("\n=== ", label, " (", endpoint, ") ===\n", sep = "")
+  cat("Params: ", paste(names(params), unlist(params), sep="=", collapse="; "), "\n", sep="")
+  url <- paste0("https://stats.wnba.com/stats/", endpoint)
+  out <- tryCatch(
+    {
+      resp <- wehoop:::request_with_proxy(url = url, params = params)
+      sets <- resp$resultSets
+      if (is.null(sets) || length(sets) == 0) {
+        cat("  -> NO resultSets in response\n")
+        return(invisible(NULL))
+      }
+      for (i in seq_along(sets)) {
+        nm <- sets[[i]]$name %||% paste0("set_", i)
+        rs <- sets[[i]]$rowSet
+        nrows <- if (is.null(rs)) 0 else nrow(rs) %||% length(rs)
+        hdrs <- sets[[i]]$headers %||% character(0)
+        cat(sprintf("  resultSet[%d] '%s': %d rows, %d cols\n",
+                    i, nm, nrows, length(hdrs)))
+        if (peek_cols && length(hdrs)) {
+          cat("    headers: ", paste(head(hdrs, 12), collapse=", "),
+              if (length(hdrs) > 12) ", ..." else "", "\n", sep = "")
+        }
+      }
+      sets
+    },
+    error = function(e) {
+      cat("  -> ERROR: ", conditionMessage(e), "\n", sep = "")
+      NULL
+    }
+  )
+  invisible(out)
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+cat("Probing 6 deprecated wehoop hustle endpoints with game_id=", game_id,
+    " season=", season, "\n", sep="")
+
+## --- 4 league-wide hustle endpoints -------------------------------------
+common_params <- list(
+  College = "", Conference = "", Country = "",
+  DateFrom = "", DateTo = "", Division = "",
+  DraftPick = "", DraftYear = "",
+  Height = "", LastNGames = 0, LeagueID = "10",
+  Location = "", Month = 0, OpponentTeamID = 0,
+  Outcome = "", PORound = "", PerMode = "Totals",
+  PlayerExperience = "", PlayerPosition = "",
+  Season = season, SeasonSegment = "", SeasonType = "Regular Season",
+  TeamID = "", VsConference = "", VsDivision = "", Weight = ""
+)
+
+probe("leaguehustlestatsplayer", "leaguehustlestatsplayer", common_params)
+
+probe("leaguehustlestatsteam",   "leaguehustlestatsteam",   common_params)
+
+leader_params <- modifyList(common_params, list(
+  PlayerOrTeam   = "Player",
+  PlayerScope    = "All Players",
+  GameScope      = "Season",
+  StatCategory   = "Deflections"
+))
+probe("leaguehustlestatsplayerleaders",
+      "leaguehustlestatsplayerleaders", leader_params)
+
+team_leader_params <- modifyList(common_params, list(
+  PlayerOrTeam   = "Team",
+  GameScope      = "Season",
+  StatCategory   = "Deflections"
+))
+probe("leaguehustlestatsteamleaders",
+      "leaguehustlestatsteamleaders", team_leader_params)
+
+## --- 2 boxscore-style hustle endpoints (game-keyed; no LeagueID) ---------
+probe("hustlestatsboxscore", "hustlestatsboxscore",
+      list(GameID = wehoop:::pad_id(game_id)))
+
+probe("boxscorehustlev2", "boxscorehustlev2",
+      list(
+        GameID        = wehoop:::pad_id(game_id),
+        StartPeriod   = 1, EndPeriod = 10,
+        StartRange    = 0, EndRange  = 28800,
+        RangeType     = 0
+      ))
+
+cat("\nDone.\n")

--- a/tools/probes/probe_known_broken.R
+++ b/tools/probes/probe_known_broken.R
@@ -1,0 +1,62 @@
+## probe_known_broken.R
+## --------------------
+## Sanity-check the endpoints that users have reported as "broken" in the
+## issue tracker (e.g. wehoop #48 wnba_leaguegamelog, hoopR #183
+## commonallplayers, hoopR #185 leaguedashplayerbiostats). Most of these
+## reports turn out to be client-fingerprinting / IP-reputation issues at
+## stats.wnba.com / stats.nba.com that affect macOS users but work fine
+## from Windows — not actual endpoint migrations.
+##
+## Run this probe from the reporter's environment if possible. If it
+## returns data, the endpoint is healthy and the report is a client-side
+## problem; if it returns HTML / empty, the endpoint is genuinely broken.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_known_broken.R
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+go <- function(label, fn, ...) {
+  cat("\n=== ", label, " ===\n", sep = "")
+  out <- tryCatch(fn(...),
+                  error = function(e) { cat("ERROR:", conditionMessage(e), "\n"); NULL })
+  if (is.null(out)) return(invisible(NULL))
+  if (is.list(out) && !is.data.frame(out)) {
+    cat("returned list, components:\n")
+    for (nm in names(out)) {
+      d <- out[[nm]]
+      if (is.data.frame(d)) {
+        cat("  $", nm, ": ", nrow(d), " rows x ", ncol(d), " cols\n", sep="")
+      } else {
+        cat("  $", nm, ": ", class(d)[1], " len=", length(d), "\n", sep="")
+      }
+    }
+  } else if (is.data.frame(out)) {
+    cat("returned data.frame: ", nrow(out), " rows x ", ncol(out), " cols\n", sep="")
+    print(head(colnames(out), 12))
+  } else {
+    cat("returned ", class(out)[1], "\n", sep="")
+  }
+  invisible(out)
+}
+
+## #48 wnba_leaguegamelog default
+go("wnba_leaguegamelog() default", wnba_leaguegamelog)
+Sys.sleep(3)
+go("wnba_leaguegamelog(league_id='10', season='2025')",
+   wnba_leaguegamelog, league_id = "10", season = "2025")
+Sys.sleep(3)
+go("wnba_leaguegamelog(league_id='10', season='2025-26')",
+   wnba_leaguegamelog, league_id = "10", season = "2025-26")
+Sys.sleep(3)
+
+## commonplayers (WNBA equivalent of NBA commonallplayers)
+go("wnba_commonallplayers(season='2025-26')",
+   wnba_commonallplayers, season = "2025-26")
+Sys.sleep(3)
+
+## sanity: scoreboardv3 worked earlier
+go("wnba_scoreboardv3(today)",
+   wnba_scoreboardv3, game_date = format(Sys.Date()-1, "%Y-%m-%d"), league_id = "10")
+
+cat("\nDone.\n")

--- a/tools/probes/probe_nba_endpoints_with_wnba_params.R
+++ b/tools/probes/probe_nba_endpoints_with_wnba_params.R
@@ -1,0 +1,180 @@
+## probe_nba_endpoints_with_wnba_params.R
+## ---------------------------------------
+## Probe NBA-only hoopR endpoints (player-tracking, league-tracking,
+## synergy, draft combine, draft history, etc.) with `LeagueID = "10"` to
+## see which ones the WNBA Stats host actually populates for WNBA. Most
+## tracking endpoints respond 200 with an empty resultSet skeleton (the
+## WNBA doesn't publish player-tracking metrics) but a few — drafthistory
+## in particular — do return WNBA data.
+##
+## Also re-probes a few endpoints that returned `MAP ERR` from
+## `wnba_stats_map_result_sets()` (typically because the response used the
+## singular `resultSet` key instead of `resultSets`) so we can see the raw
+## shape for parser fixes.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_nba_endpoints_with_wnba_params.R
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+probe_raw <- function(label, endpoint, params) {
+  cat("\n=== ", label, " (", endpoint, ") ===\n", sep = "")
+  url <- paste0("https://stats.wnba.com/stats/", endpoint)
+  resp <- tryCatch(
+    wehoop:::request_with_proxy(url = url, params = params),
+    error = function(e) { cat("  HTTP ERR:", conditionMessage(e), "\n"); NULL }
+  )
+  if (is.null(resp)) return(invisible(NULL))
+  cat("  resp top-level: ", paste(names(resp), collapse=", "), "\n", sep="")
+  if (!is.null(resp$resultSets)) {
+    cat("  resultSets class:", class(resp$resultSets)[1], "\n")
+    if (is.data.frame(resp$resultSets)) {
+      cat("  resultSets has", nrow(resp$resultSets), "named result-sets:",
+          paste(resp$resultSets$name, collapse=", "), "\n")
+      for (i in seq_len(nrow(resp$resultSets))) {
+        rs <- resp$resultSets$rowSet[[i]]
+        cat(sprintf("    [%s] rows=%d cols=%d\n",
+                    resp$resultSets$name[i],
+                    length(rs),
+                    length(resp$resultSets$headers[[i]])))
+      }
+    }
+  }
+  if (!is.null(resp$resultSet)) {
+    cat("  resultSet (singular) class:", class(resp$resultSet)[1], "\n")
+    cat("  resultSet$name:", resp$resultSet$name %||% "<null>", "\n")
+    cat("  resultSet$headers:", length(resp$resultSet$headers %||% c()), "\n")
+    cat("  resultSet$rowSet:", length(resp$resultSet$rowSet %||% list()), "rows\n")
+  }
+  Sys.sleep(3)
+  invisible(resp)
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+game_id   <- "1022600021"
+season_yy <- "2025-26"
+
+## ----- (A) Re-probe the two failing redirect targets -----
+
+## leagueleaders had `resp$resultSet[[1]]` subscript fail — that means the
+## endpoint returned the singular `resultSet` key (not plural `resultSets`)
+## which is what wnba_stats_map_result_sets falls back to but with a list
+## structure mismatch when only one resultSet exists.
+probe_raw("leagueleaders PerGame PTS", "leagueleaders",
+          list(LeagueID = "10", PerMode = "PerGame", StatCategory = "PTS",
+               Season = season_yy, SeasonType = "Regular Season",
+               Scope = "S", ActiveFlag = "No"))
+
+probe_raw("leagueleaders Totals", "leagueleaders",
+          list(LeagueID = "10", PerMode = "Totals", StatCategory = "PTS",
+               Season = season_yy, SeasonType = "Regular Season",
+               Scope = "S", ActiveFlag = "No"))
+
+## videodetailsasset — try a simpler param set, maybe last-shot context
+probe_raw("videodetailsasset minimal", "videodetailsasset",
+          list(LeagueID = "10", Season = season_yy,
+               SeasonType = "Regular Season",
+               TeamID = 0, PlayerID = 1628932, GameID = "",
+               ContextMeasure = "FGM"))
+
+## ----- (B) NBA-only hoopR functions not in wehoop — test LeagueID=10 -----
+
+## These exist in hoopR but the equivalent wnba_ wrapper isn't exported.
+## Endpoints worth checking:
+## - playerdashptpass (passing tracking)
+## - playerdashptreb (rebounding tracking)
+## - playerdashptshotdefend (shot defense tracking)
+## - playerdashptshots (shot tracking)
+## - leaguedashptdefend (league defensive tracking)
+## - leaguedashptstats (league passing/rebound tracking)
+## - leaguedashptteamdefend (team defensive tracking)
+## - shotchartdetail (already in wehoop?)
+## - synergyplaytypes
+## - draftcombinestats / draftcombineplayeranthro
+
+## A'ja Wilson (PLAYER_ID 1628932) on Aces (TEAM_ID 1611661319)
+team_id   <- "1611661319"
+player_id <- "1628932"
+
+probe_raw("playerdashptpass (A'ja)", "playerdashptpass",
+          list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+               SeasonType = "Regular Season",
+               LastNGames = 0, Month = 0, OpponentTeamID = 0,
+               PlayerID = player_id, TeamID = team_id,
+               DateFrom = "", DateTo = "", GameSegment = "",
+               Location = "", Outcome = "", SeasonSegment = "",
+               VsConference = "", VsDivision = ""))
+
+probe_raw("playerdashptreb (A'ja)", "playerdashptreb",
+          list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+               SeasonType = "Regular Season",
+               LastNGames = 0, Month = 0, OpponentTeamID = 0,
+               PlayerID = player_id, TeamID = team_id,
+               DateFrom = "", DateTo = "", GameSegment = "",
+               Location = "", Outcome = "", SeasonSegment = "",
+               VsConference = "", VsDivision = ""))
+
+probe_raw("playerdashptshots (A'ja)", "playerdashptshots",
+          list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+               SeasonType = "Regular Season",
+               LastNGames = 0, Month = 0, OpponentTeamID = 0,
+               PlayerID = player_id, TeamID = team_id,
+               DateFrom = "", DateTo = "", GameSegment = "",
+               Location = "", Outcome = "", SeasonSegment = "",
+               VsConference = "", VsDivision = ""))
+
+probe_raw("playerdashptshotdefend (A'ja)", "playerdashptshotdefend",
+          list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+               SeasonType = "Regular Season",
+               LastNGames = 0, Month = 0, OpponentTeamID = 0,
+               PlayerID = player_id, TeamID = team_id,
+               DateFrom = "", DateTo = "", GameSegment = "",
+               Location = "", Outcome = "", SeasonSegment = "",
+               VsConference = "", VsDivision = ""))
+
+probe_raw("leaguedashptdefend", "leaguedashptdefend",
+          list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+               SeasonType = "Regular Season",
+               DefenseCategory = "Overall",
+               College = "", Conference = "", Country = "",
+               DateFrom = "", DateTo = "", Division = "",
+               DraftPick = "", DraftYear = "", GameSegment = "",
+               Height = "", LastNGames = 0, Location = "",
+               Month = 0, OpponentTeamID = 0, Outcome = "",
+               PORound = "", PlayerExperience = "", PlayerID = 0,
+               PlayerPosition = "", SeasonSegment = "",
+               StarterBench = "", TeamID = 0, VsConference = "",
+               VsDivision = "", Weight = ""))
+
+probe_raw("leaguedashptstats", "leaguedashptstats",
+          list(LeagueID = "10", PerMode = "PerGame", Season = season_yy,
+               SeasonType = "Regular Season",
+               PlayerOrTeam = "Player", PtMeasureType = "SpeedDistance",
+               College = "", Conference = "", Country = "",
+               DateFrom = "", DateTo = "", Division = "",
+               DraftPick = "", DraftYear = "", GameScope = "",
+               Height = "", LastNGames = 0, Location = "",
+               Month = 0, OpponentTeamID = 0, Outcome = "",
+               PORound = "", PlayerExperience = "", PlayerPosition = "",
+               SeasonSegment = "", StarterBench = "", TeamID = 0,
+               VsConference = "", VsDivision = "", Weight = ""))
+
+probe_raw("synergyplaytypes player", "synergyplaytypes",
+          list(LeagueID = "10", PerMode = "PerGame", PlayerOrTeam = "P",
+               SeasonType = "Regular Season",
+               SeasonYear = season_yy, PlayType = "Isolation",
+               TypeGrouping = "offensive"))
+
+probe_raw("draftcombinestats", "draftcombinestats",
+          list(LeagueID = "10", SeasonYear = "2024"))
+
+probe_raw("draftcombineplayeranthro", "draftcombineplayeranthro",
+          list(LeagueID = "10", SeasonYear = "2024"))
+
+probe_raw("drafthistory", "drafthistory",
+          list(LeagueID = "10", Season = "2024",
+               TeamID = 0, RoundNum = 0, RoundPick = 0,
+               OverallPick = 0, TopX = 0, College = ""))
+
+cat("\nDone.\n")

--- a/tools/probes/probe_param_order_sensitivity.R
+++ b/tools/probes/probe_param_order_sensitivity.R
@@ -1,0 +1,66 @@
+## probe_param_order_sensitivity.R
+## --------------------------------
+## Diagnose query-string parameter-order sensitivity. As of 2026, the WNBA
+## (and NBA) Stats API at `stats.wnba.com/stats/leaguegamelog` returns a
+## Cloudflare HTML error page when params are sent in alphabetical order
+## (`Counter, DateFrom, DateTo, Direction, LeagueID, ...`) but a populated
+## `LeagueGameLog` resultSet for the `LeagueID`-first ordering that the
+## nba.com client uses. Same param *values* in both cases — only the
+## key order differs.
+##
+## This probe sends the same params twice — once in each order — so you
+## can confirm/disprove the sensitivity for any endpoint where the wrapper
+## starts returning HTML but the URL looks right.
+##
+## Originally written for `wnba_leaguegamelog()`. Repurpose by swapping
+## the `url` and `params` lists below.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_param_order_sensitivity.R
+options(warn=1)
+suppressPackageStartupMessages(devtools::load_all(quiet=TRUE))
+url <- "https://stats.wnba.com/stats/leaguegamelog"
+
+# Wrapper-order params
+wrapper_params <- list(
+  Counter      = 0,
+  DateFrom     = "",
+  DateTo       = "",
+  Direction    = "ASC",
+  LeagueID     = "10",
+  PlayerOrTeam = "T",
+  Season       = 2025,
+  SeasonType   = "Regular Season",
+  Sorter       = "DATE"
+)
+
+# My-probe-order params
+probe_params <- list(
+  LeagueID     = "10",
+  Season       = 2025,
+  SeasonType   = "Regular Season",
+  PlayerOrTeam = "T",
+  Counter      = 0,
+  Direction    = "ASC",
+  Sorter       = "DATE",
+  DateFrom     = "",
+  DateTo       = ""
+)
+
+tries <- list(
+  list(label = "wrapper order", params = wrapper_params),
+  list(label = "probe order",   params = probe_params)
+)
+
+for (t in tries) {
+  Sys.sleep(4)
+  cat("\n=== ", t$label, " ===\n", sep = "")
+  out <- tryCatch(
+    wehoop:::request_with_proxy(url = url, params = t$params),
+    error = function(e) conditionMessage(e)
+  )
+  if (is.character(out)) cat("  ERR:", substr(out, 1, 80), "\n")
+  else if (!is.null(out$resultSets) && is.data.frame(out$resultSets))
+    cat("  rows=", length(out$resultSets$rowSet[[1]]), "\n", sep = "")
+  else cat("  no resultSets\n")
+}

--- a/tools/probes/probe_schedule_endpoints.R
+++ b/tools/probes/probe_schedule_endpoints.R
@@ -1,0 +1,145 @@
+## probe_schedule_endpoints.R
+## --------------------------
+## Hunts for a working schedule endpoint when the primary one fails. Tries
+## every URL pattern the NBA/WNBA stack is known to expose schedules
+## through — both the `stats.*` API host (with x-nba-stats-* headers) and
+## the `cdn.*` static-JSON host (browser-ish headers only).
+##
+## Originally written to find the `cdn.wnba.com/static/json/staticData/
+## scheduleLeagueV2.json` replacement after `stats.wnba.com/stats/
+## scheduleleaguev2` was retired in March 2026 (wehoop #53, hoopR #184).
+## Keep updated as new candidate endpoints surface.
+##
+## Reports HTTP status, byte count, and JSON skeleton (top-level keys +
+## leagueSchedule.gameDates count) per candidate.
+##
+## Run from package root:
+##   Rscript tools/probes/probe_schedule_endpoints.R
+options(warn = 1)
+suppressPackageStartupMessages({
+  library(httr2)
+  library(jsonlite)
+})
+
+ua <- "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+probe <- function(label, url, params = NULL, headers = list(), is_cdn = FALSE) {
+  cat("\n=== ", label, " ===\n  URL: ", url, "\n", sep = "")
+  hdrs_default <- if (is_cdn) {
+    list(
+      "User-Agent"      = ua,
+      "Accept"          = "application/json, text/plain, */*",
+      "Accept-Language" = "en-US,en;q=0.9",
+      "Origin"          = "https://www.wnba.com",
+      "Referer"         = "https://www.wnba.com/"
+    )
+  } else {
+    list(
+      "User-Agent"         = ua,
+      "Accept"             = "application/json, text/plain, */*",
+      "Accept-Language"    = "en-US,en;q=0.9",
+      "Origin"             = "https://stats.wnba.com",
+      "Referer"            = "https://www.wnba.com/",
+      "x-nba-stats-origin" = "stats",
+      "x-nba-stats-token"  = "true"
+    )
+  }
+  hdrs <- modifyList(hdrs_default, headers)
+  req <- httr2::request(url) |>
+    httr2::req_headers(!!!hdrs) |>
+    httr2::req_timeout(45) |>
+    httr2::req_retry(max_tries = 3, backoff = function(i) 1 + i,
+                     is_transient = function(resp) TRUE)
+  if (!is.null(params)) req <- httr2::req_url_query(req, !!!params)
+  out <- tryCatch(httr2::req_perform(req),
+                  error = function(e) { cat("  ERROR:", conditionMessage(e), "\n"); NULL })
+  if (is.null(out)) return(invisible(NULL))
+  cat("  status:", httr2::resp_status(out), "  bytes:",
+      nchar(httr2::resp_body_string(out)), "\n")
+  if (httr2::resp_status(out) >= 400) {
+    cat("  body head:", substr(httr2::resp_body_string(out), 1, 200), "\n")
+    return(invisible(NULL))
+  }
+  body <- httr2::resp_body_string(out)
+  parsed <- tryCatch(jsonlite::fromJSON(body, simplifyVector = FALSE),
+                     error = function(e) { cat("  PARSE ERROR:", conditionMessage(e), "\n"); NULL })
+  if (is.null(parsed)) return(invisible(NULL))
+  cat("  top-level keys: ", paste(head(names(parsed), 10), collapse=", "), "\n", sep="")
+  # peek deeper
+  walk <- function(x, depth = 1, prefix = "") {
+    if (depth > 3) return()
+    if (is.list(x) && length(x)) {
+      for (nm in head(names(x), 8)) {
+        sub <- x[[nm]]
+        klass <- class(sub)[1]
+        len <- length(sub)
+        cat(prefix, "  $", nm, " (", klass, ", len=", len, ")\n", sep="")
+        if (is.list(sub) && depth < 3) walk(sub, depth + 1, paste0(prefix, "  "))
+      }
+    }
+  }
+  walk(parsed)
+  invisible(parsed)
+}
+
+## ---- 1) Original (confirmed dead) ----
+probe("ORIGINAL stats.wnba.com/stats/scheduleleaguev2 (LeagueID=10)",
+      "https://stats.wnba.com/stats/scheduleleaguev2",
+      params = list(LeagueID = "10", Season = "2025"))
+
+## ---- 2) v3 successor on stats host ----
+probe("stats.wnba.com/stats/scheduleleaguev3",
+      "https://stats.wnba.com/stats/scheduleleaguev3",
+      params = list(LeagueID = "10", Season = "2025"))
+
+## ---- 3) International variant ----
+probe("stats.wnba.com/stats/scheduleleaguev2int",
+      "https://stats.wnba.com/stats/scheduleleaguev2int",
+      params = list(LeagueID = "10", Season = "2025"))
+
+## ---- 4) CDN static JSON variants ----
+probe("CDN cdn.wnba.com/static/json/staticData/scheduleLeagueV2.json",
+      "https://cdn.wnba.com/static/json/staticData/scheduleLeagueV2.json",
+      is_cdn = TRUE)
+
+probe("CDN cdn.wnba.com/static/json/staticData/scheduleLeagueV2_1.json",
+      "https://cdn.wnba.com/static/json/staticData/scheduleLeagueV2_1.json",
+      is_cdn = TRUE)
+
+probe("CDN cdn.wnba.com/static/json/staticData/scheduleLeagueV2_2.json",
+      "https://cdn.wnba.com/static/json/staticData/scheduleLeagueV2_2.json",
+      is_cdn = TRUE)
+
+probe("CDN cdn.wnba.com/static/json/staticData/scheduleLeagueV2_3.json",
+      "https://cdn.wnba.com/static/json/staticData/scheduleLeagueV2_3.json",
+      is_cdn = TRUE)
+
+## ---- 5) Live data ----
+probe("CDN cdn.wnba.com/static/json/liveData/scoreboard/todaysScoreboard_10.json",
+      "https://cdn.wnba.com/static/json/liveData/scoreboard/todaysScoreboard_10.json",
+      is_cdn = TRUE)
+
+## ---- 6) Internal-only alt (data.wnba.com legacy) ----
+probe("data.wnba.com/data/10s/prod/v2/2025/schedule.json",
+      "https://data.wnba.com/data/10s/prod/v2/2025/schedule.json",
+      is_cdn = TRUE)
+
+probe("data.wnba.com/data/10s/prod/v1/2025/schedule.json",
+      "https://data.wnba.com/data/10s/prod/v1/2025/schedule.json",
+      is_cdn = TRUE)
+
+## ---- 7) WNBA app schedule (mobile) ----
+probe("CDN cdn.wnba.com/static/json/staticData/leagueSchedule_10.json",
+      "https://cdn.wnba.com/static/json/staticData/leagueSchedule_10.json",
+      is_cdn = TRUE)
+
+## ---- 8) Older NBA-style endpoint variants on stats host ----
+probe("stats.wnba.com/stats/scheduleseason",
+      "https://stats.wnba.com/stats/scheduleseason",
+      params = list(LeagueID = "10", Season = "2025-26"))
+
+probe("stats.wnba.com/stats/internationalbroadcasterschedule",
+      "https://stats.wnba.com/stats/internationalbroadcasterschedule",
+      params = list(LeagueID = "10", Season = "2025-26"))
+
+cat("\nDone.\n")

--- a/tools/probes/verify_wrapper_changes.R
+++ b/tools/probes/verify_wrapper_changes.R
@@ -1,0 +1,64 @@
+## verify_wrapper_changes.R
+## ------------------------
+## End-to-end smoke test for the wrappers touched in any given PR. Calls
+## each one against the live WNBA Stats API / CDN and prints a one-line
+## class + shape summary so you can eyeball that the wrapper returns the
+## right kind of object (list of data.frames vs single data.frame) with
+## non-zero rows.
+##
+## Update the `verdict()` block list to match whatever wrappers your PR
+## touches. Lighter-weight than the testthat suite; use this for the
+## "did I break anything obvious" check before running `devtools::test()`.
+##
+## Run from package root:
+##   Rscript tools/probes/verify_wrapper_changes.R
+options(warn = 1)
+suppressPackageStartupMessages(devtools::load_all(quiet = TRUE))
+
+verdict <- function(label, expr) {
+  cat("\n--- ", label, " ---\n", sep = "")
+  out <- tryCatch(expr, error = function(e) { cat("  ERROR: ", conditionMessage(e), "\n"); structure(NULL, error = TRUE) })
+  if (!is.null(attr(out, "error"))) return(invisible(NULL))
+  if (is.list(out) && !is.data.frame(out)) {
+    cat("  list with", length(out), "components:\n")
+    for (nm in names(out)) {
+      d <- out[[nm]]
+      if (is.data.frame(d)) cat("    ", nm, ": ", nrow(d), "x", ncol(d), "\n")
+      else cat("    ", nm, ": ", class(d)[1], " len=", length(d), "\n")
+    }
+  } else if (is.data.frame(out)) {
+    cat("  data.frame: ", nrow(out), "x", ncol(out), "\n", sep = "")
+    cat("  first 5 cols: ", paste(head(colnames(out), 5), collapse=", "), "\n", sep="")
+  } else {
+    cat("  ", class(out)[1], " len=", length(out), "\n", sep="")
+  }
+  invisible(out)
+}
+
+verdict("wnba_schedule()  (CDN migration)", wnba_schedule())
+Sys.sleep(3)
+
+verdict("wnba_schedule(season=2024)  (historical season warning)",
+        wnba_schedule(season = 2024))
+Sys.sleep(3)
+
+verdict("wnba_leaguegamelog()  (default now '10')", wnba_leaguegamelog())
+Sys.sleep(3)
+
+verdict("wnba_playerprofilev2(player_id='1628932')  (un-deprecated)",
+        wnba_playerprofilev2(player_id = '1628932'))
+Sys.sleep(3)
+
+verdict("wnba_teaminfocommon(team_id='1611661319')  (un-deprecated)",
+        wnba_teaminfocommon(team_id = '1611661319'))
+Sys.sleep(3)
+
+verdict("wnba_teamyearbyyearstats(team_id='1611661319')  (un-deprecated)",
+        wnba_teamyearbyyearstats(team_id = '1611661319'))
+Sys.sleep(3)
+
+verdict("wnba_leaguelineupviz()  (un-deprecated)",
+        wnba_leaguelineupviz(season = "2025-26"))
+Sys.sleep(3)
+
+cat("\nDone.\n")


### PR DESCRIPTION
## Summary

Adds 9 manual probe scripts + an index README under `tools/probes/`. Each
probe targets a specific WNBA Stats API failure mode that surfaced during
the resilience pass in #54 — the kind of "is this endpoint dead, or is my
client just being fingerprinted?" question that's annoying to answer
from scratch every season.

These are diagnostic tools, not tests. They print to stdout, hit the live
API, and aren't run by `devtools::check()` (`tools/` is already in
`.Rbuildignore` via `^tools$`). Zero impact on the package build, the
test suite, the namespace, or downstream users.

## Why ship these

Every time the WNBA Stats API breaks something mid-season we end up
writing the same probe twice — once to diagnose, once a season later to
re-verify. Co-locating the scripts in `tools/probes/` means:

- The "which endpoint did `scheduleleaguev2` move to" investigation
  doesn't have to start from a blank file.
- When a user reports `wnba_<fn>()` is broken, you can hand them
  `Rscript tools/probes/probe_known_broken.R` and disentangle
  endpoint-dead from client-fingerprinting in one command.
- When hoopR adds a `lifecycle::deprecate_stop(with = "nba_X")`
  redirect, `probe_hoopr_redirect_targets.R` answers in one run whether
  `wnba_X` actually returns WNBA data before you adopt the recommendation.

## Files

| Script | Purpose |
| --- | --- |
| `probe_hustle_deprecated.R` | Sweeps all 6 hustle-family endpoints currently `deprecate_stop()`-ed |
| `probe_hustle_boxscore_deep.R` | Deep-dive on `hustlestatsboxscore` across multiple games (the one with the misleading `HUSTLE_STATUS=1` + empty rows shape) |
| `probe_schedule_endpoints.R` | Hunts a working schedule endpoint when the primary one fails. Originally found the CDN replacement in #54 |
| `probe_cdn_payload.R` | Verifies a candidate CDN endpoint is parser-compatible with the existing unnest pipeline |
| `probe_known_broken.R` | Sanity-check user-reported broken endpoints — disentangle endpoint-dead from client-fingerprinting |
| `probe_hoopr_redirect_targets.R` | Probe every hoopR `with =` redirect target for WNBA data |
| `probe_nba_endpoints_with_wnba_params.R` | Probe NBA-only hoopR endpoints with `LeagueID="10"` |
| `probe_param_order_sensitivity.R` | Diagnose query-string param-order sensitivity (the `LeagueID`-first issue from #54) |
| `verify_wrapper_changes.R` | End-to-end smoke test for wrappers touched in a PR — lighter than `devtools::test()` |

Plus `tools/probes/README.md` — index keyed by failure mode, common
conventions (use `request_with_proxy()` + `wnba_stats_map_result_sets()`
for `stats.wnba.com`, bare `httr2` for the CDN), and the per-season
constant-update procedure.

## Test plan

- [x] All 9 probes copied from the session worktree, headers polished to
  explain what + why + when to use
- [x] Smoke-tested `verify_wrapper_changes.R` at the new
  `tools/probes/` path — runs end-to-end against the live API
- [x] No new package imports; no `R/`, `man/`, `NAMESPACE`,
  `DESCRIPTION`, `NEWS.md`, or `tests/` changes — this PR is strictly
  additive to `tools/probes/`
- [x] `^tools$` already in `.Rbuildignore`; scripts won't surface as
  `R CMD check` notes
