### PR TITLE
fix(crosswalk): dedupe ESPN games in wbb_schedule_crosswalk (4x scoreboard-group inflation)

### DIFF
--- a/R/wbb_crosswalk.R
+++ b/R/wbb_crosswalk.R
@@ -321,6 +321,11 @@ wbb_team_crosswalk <- function(season = most_recent_wbb_season(),
     espn_game_id     = as.character(.data$espn_game_id),
     .pair_key        = .pair_key(.data$home_espn_team_id, .data$away_espn_team_id)
   )
+  # De-duplicate ESPN games: espn_wbb_scoreboard() returns each game once per
+  # ESPN group (D-I, conference tournaments, etc.), so the per-date pull yields
+  # multiple identical rows per game; collapse to one before the join to avoid
+  # a row blow-up.
+  espn2 <- espn2[!duplicated(espn2$espn_game_id), , drop = FALSE]
 
   # Torvik side — keep ALL games; those where either team name cannot be
   # resolved to an ESPN id get a NA pair_key and surface as bart_only rows
@@ -341,6 +346,8 @@ wbb_team_crosswalk <- function(season = most_recent_wbb_season(),
   bart2$.pair_key <- .pair_key(bart2$.t1_id, bart2$.t2_id)
   bart2$.t1_id <- NULL
   bart2$.t2_id <- NULL
+  # Defensive: one row per Torvik game id.
+  bart2 <- bart2[!duplicated(bart2$bart_muid), , drop = FALSE]
 
   key <- c("game_date", ".pair_key")
   out <- dplyr::full_join(espn2, bart2, by = key) |>

--- a/tests/testthat/test-wbb_crosswalk.R
+++ b/tests/testthat/test-wbb_crosswalk.R
@@ -228,6 +228,26 @@ test_that(".bb_assemble_schedule_crosswalk_wbb joins ESPN + Torvik on date + pai
   expect_equal(result$away_espn_team_id, 200L)
 })
 
+test_that(".bb_assemble_schedule_crosswalk_wbb dedupes ESPN games repeated across scoreboard groups", {
+  # espn_wbb_scoreboard() returns each game once per ESPN group (D-I, conference
+  # tournaments, etc.), so the per-date pull can contain several identical rows
+  # for one game. The assembler must collapse them to a single joined row.
+  # Regression for the WBB schedule crosswalk 24,683-row (~4x) blow-up.
+  xw <- .make_xwalk_for_sched()
+  eg <- .make_espn_games()
+  eg <- eg[rep(1L, 4L), , drop = FALSE]   # 4 identical copies of the same game
+  bg <- .make_bart_games_for_sched()
+
+  result <- .bb_assemble_schedule_crosswalk_wbb(
+    espn_games = eg, bart_games = bg, team_xwalk = xw, season = 2025L
+  )
+
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$match_method, "both")
+  expect_equal(result$espn_game_id, "401234567")
+  expect_equal(result$bart_muid, "BT-001")
+})
+
 test_that(".bb_assemble_schedule_crosswalk_wbb espn-only row when Torvik absent", {
   xw <- .make_xwalk_for_sched()
   eg <- .make_espn_games()


### PR DESCRIPTION
`espn_wbb_scoreboard()` returns each game once per ESPN **group** (D-I, conference tournaments, etc.), so the per-date pull in `wbb_schedule_crosswalk()` contained ~4 identical rows per game. The full-join then inflated the WBB schedule crosswalk to **24,683 rows for only ~6,138 real games** (each `espn_game_id` ↔ exactly one `bart_muid`, just duplicated ~4×).

Fix: de-duplicate the ESPN frame on `espn_game_id` (and, defensively, the Torvik frame on `bart_muid`) before the pair-key full-join. Adds a regression test (4 identical ESPN copies → 1 joined row).

## Test Plan
- [x] `test-wbb_crosswalk.R` 63 pass (incl. new dedupe regression test)
- [x] Will rebuild + republish the `wbb_crosswalk` schedule artifact after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where duplicate women's basketball game entries were being improperly multiplied during schedule data integration, ensuring accurate game counts and preventing data duplication.

* **Tests**
  * Added test coverage to verify proper deduplication of duplicate game entries in schedule crosswalk data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->