### PR TITLE
fix(espn): derive boxscore availability from the payload, not the header flag

### DIFF
--- a/R/espn_wbb_data.R
+++ b/R/espn_wbb_data.R
@@ -3178,9 +3178,11 @@ helper_espn_wbb_team_box <- function(resp) {
     lubridate::with_tz(tzone = "America/New_York")
 
   game_date <- as.Date(substr(game_date_time, 0, 10))
-  box_score_available <- game_json[["header"]][["competitions"]][[
-    "boxscoreAvailable"
-  ]]
+  # ESPN's header `boxscoreAvailable` flag is unreliable for archival games
+  # (pre-2014 WBB payloads carry full team statistics while the flag says
+  # FALSE), so availability is derived from the payload itself; the
+  # statistics-length check below remains the real gate.
+  box_score_available <- length(game_json[["boxscore"]][["teams"]]) > 0
   if (box_score_available == TRUE) {
     teams_box_score_df <- game_json[["boxscore"]][["teams"]] %>%
       jsonlite::toJSON() %>%
@@ -3520,8 +3522,11 @@ helper_espn_wbb_player_box <- function(resp) {
       purrr::pluck(7) %>%
       as.numeric()
   )
+  # Payload presence replaces ESPN's unreliable header `boxscoreAvailable`
+  # flag (archival games carry stats while the flag says FALSE); the athlete
+  # and stat validity conjuncts below remain the real gate.
   if (
-    boxScoreAvailable == TRUE &&
+    length(game_json[["boxscore"]][["players"]]) > 0 &&
       length(players_box_score_df[["statistics"]][[1]][["athletes"]][[1]]) >
         1 &&
       length(players_box_score_df[["statistics"]][[1]][["athletes"]][[1]][[

--- a/R/espn_wnba_data.R
+++ b/R/espn_wnba_data.R
@@ -2347,7 +2347,11 @@ helper_espn_wnba_team_box <- function(resp){
     lubridate::with_tz(tzone = "America/New_York")
   
   game_date <- as.Date(substr(game_date_time, 0, 10))
-  box_score_available <- game_json[["header"]][["competitions"]][["boxscoreAvailable"]]
+  # ESPN's header `boxscoreAvailable` flag is unreliable for archival games
+  # (the WBB twin drops pre-2014 boxscores over it), so availability is
+  # derived from the payload itself; the statistics-length check below
+  # remains the real gate.
+  box_score_available <- length(game_json[["boxscore"]][["teams"]]) > 0
   if (box_score_available == TRUE) {
     teams_box_score_df <- game_json[["boxscore"]][["teams"]] %>%
       jsonlite::toJSON() %>%
@@ -2580,7 +2584,10 @@ helper_espn_wnba_player_box <- function(resp){
       purrr::pluck(7) %>% 
       as.numeric()
   )
-  if (boxScoreAvailable == TRUE &&
+  # Payload presence replaces ESPN's unreliable header `boxscoreAvailable`
+  # flag (archival games carry stats while the flag says FALSE); the athlete
+  # and stat validity conjuncts below remain the real gate.
+  if (length(game_json[["boxscore"]][["players"]]) > 0 &&
       length(players_box_score_df[["statistics"]][[1]][["athletes"]][[1]]) > 1 &&
       !is.na(valid_stats)) {
       players_df <- players_box_score_df %>%


### PR DESCRIPTION
## What

ESPN's `header.competitions.boxscoreAvailable` flag is **unreliable for archival games**: most pre-2014 WBB final payloads carry full `boxscore.teams[].statistics` while the flag says `FALSE`. Sampled 20 evenly-spaced 2012 games from wehoop-wbb-raw: **6 carry complete team statistics under a false flag**, and the live ESPN summary API serves the same data. `helper_espn_wbb_team_box` / `helper_espn_wbb_player_box` gated on the flag and silently dropped those games — which is why the compiled `team_box_2009..2013` parquet in wehoop-wbb-data holds 10–280 rows against ~5,400-game seasons.

## Change

All four helpers (WBB + WNBA team/player box) now derive availability from the payload (`boxscore.teams` / `boxscore.players` presence); the existing statistics-length and athlete-validity checks remain the real gate, so genuinely boxless games still return empty exactly as before.

## Verification

Ran the patched helpers on the 2012 national championship payload (flag `FALSE`, stats present): `helper_espn_wbb_team_box` → 2×54, `helper_espn_wbb_player_box` → 10 rows — both previously empty. Genuinely boxless payloads still return empty (inner gates unchanged).

## Related

- Python twin fixed in sportsdataverse-py (`helper_wbb_team_box`/`helper_wbb_player_box` ported the same gate faithfully) — that side carries the regression fixture.
- Follow-up: hoopR's MBB/NBA helpers have the same latent gate (ESPN's men's archival flags happen to be more reliable, so it hasn't bitten there).