### PR TITLE
fix(docs): address player_core review findings + repair the pkgdown reference index

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -36,3 +36,4 @@
 ^debug\.log$
 ^nul$
 ^.*\.log$
+^data-raw$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,11 @@
 ^README\.Rmd$
 ^cran-comments\.md$
 ^CRAN-RELEASE$
+^\.omc$
+^\.remember$
+^\.ruff_cache$
+^\.pytest_cache$
+^\.understand-anything$
+^\.superpowers$
+^\.claude$
+^\.vscode$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -33,3 +33,6 @@
 ^\.superpowers$
 ^\.claude$
 ^\.vscode$
+^debug\.log$
+^nul$
+^.*\.log$

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ wbb_pbp_db*
 .claude/
 .understand-anything/
 .gemini/
+debug.log
+nul
+*.log

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -517,6 +517,7 @@ importFrom(stringr,
   str_split,
   str_squish
 )
+importFrom(tibble,as_tibble)
 importFrom(tidyr,
   everything,
   hoist,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -517,7 +517,6 @@ importFrom(stringr,
   str_split,
   str_squish
 )
-importFrom(tibble,as_tibble)
 importFrom(tidyr,
   everything,
   hoist,

--- a/R/bart_wbb.R
+++ b/R/bart_wbb.R
@@ -2,7 +2,10 @@
 # Mirrors hoopR's men's torvik_* functions against the /ncaaw/ raw data files,
 # using wehoop's shared HTTP + data-class helpers. No API key required.
 
-.bart_wbb_base_url <- "https://barttorvik.com/ncaaw/"
+# No trailing slash: callers pass paths that begin with "/" (see
+# .bart_wbb_text() below), so a slash here would build ".../ncaaw//2024_...".
+# The trailing slash the URL checker wants belongs on the DOC links only.
+.bart_wbb_base_url <- "https://barttorvik.com/ncaaw"
 .bart_wbb_user_agent <- "Mozilla/5.0 (wehoop; +https://wehoop.sportsdataverse.org)"
 
 #' Internal: GET a barttorvik.com/ncaaw resource and return the response text

--- a/R/bart_wbb.R
+++ b/R/bart_wbb.R
@@ -2,7 +2,7 @@
 # Mirrors hoopR's men's torvik_* functions against the /ncaaw/ raw data files,
 # using wehoop's shared HTTP + data-class helpers. No API key required.
 
-.bart_wbb_base_url <- "https://barttorvik.com/ncaaw"
+.bart_wbb_base_url <- "https://barttorvik.com/ncaaw/"
 .bart_wbb_user_agent <- "Mozilla/5.0 (wehoop; +https://wehoop.sportsdataverse.org)"
 
 #' Internal: GET a barttorvik.com/ncaaw resource and return the response text
@@ -19,7 +19,7 @@
 #' **Bart Torvik Women's T-Rank Ratings**
 #' @description
 #' **Get women's college basketball T-Rank team ratings and adjusted
-#' efficiencies from [barttorvik.com](https://barttorvik.com/ncaaw).** Pulls the
+#' efficiencies from [barttorvik.com](https://barttorvik.com/ncaaw/).** Pulls the
 #' `/ncaaw/{year}_team_results.csv` file (one row per team). No API key required.
 #' @param year Season, 4-digit ending-year format (e.g. `2024`). Defaults to
 #'   `most_recent_wbb_season()`.
@@ -57,7 +57,7 @@ bart_wbb_ratings <- function(year = most_recent_wbb_season()) {
 #' **Bart Torvik Women's Season Schedule & Results**
 #' @description
 #' **Get the full women's game-by-game schedule and results for a season from
-#' [barttorvik.com](https://barttorvik.com/ncaaw).** Pulls the
+#' [barttorvik.com](https://barttorvik.com/ncaaw/).** Pulls the
 #' `/ncaaw/{year}_super_sked.json` file (one row per game). No API key required.
 #' @param year Season, 4-digit ending-year format (e.g. `2024`). Defaults to
 #'   `most_recent_wbb_season()`.

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -81,10 +81,16 @@ NULL
 #'
 #' @examples
 #' \donttest{
+#'   # Split across lines to keep the Rd under the line-width limit; the
+#'   # core-v2 $ref URLs are long enough to be truncated in the PDF manual.
+#'   team_ref <- paste0(
+#'     "http://sports.core.api.espn.com/v2/sports/basketball/",
+#'     "leagues/wnba/seasons/2025/teams/22"
+#'   )
 #'   payload <- list(
 #'     guid = "abc", fullName = "Jane Doe", jersey = "23",
 #'     position = list(id = "5", abbreviation = "G"),
-#'     team = list(`$ref` = "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2025/teams/22")
+#'     team = list(`$ref` = team_ref)
 #'   )
 #'   espn_basketball_player_core(payload, athlete_id = 1966)
 #' }

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -158,9 +158,7 @@ espn_basketball_player_core <- function(payload, athlete_id) {
     active = .pc_lgl(payload[["active"]])
   )
 
-  tibble::as_tibble(row[cols]) %>%
-    janitor::clean_names() %>%
-    make_wehoop_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
+  .player_core_finalize(tibble::as_tibble(row[cols]))
 }
 
 #' The released column order. Order is part of the contract -- both pipelines
@@ -200,7 +198,17 @@ espn_basketball_player_core <- function(payload, athlete_id) {
   # The empty path is finalized identically to the populated one, so a caller
   # that chains on the result sees the same class and attributes whether or not
   # the payload had anything in it.
-  tibble::as_tibble(proto) %>%
+  .player_core_finalize(tibble::as_tibble(proto))
+}
+
+#' Apply the package data contract to a player_core frame.
+#'
+#' Both return paths go through here so they cannot drift: the type string in
+#' particular was previously written out twice, which is one edit away from the
+#' two paths disagreeing about what they claim to be.
+#' @noRd
+.player_core_finalize <- function(df) {
+  df %>%
     janitor::clean_names() %>%
     make_wehoop_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
 }

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -96,7 +96,6 @@ NULL
 #' published and neither depends on the other, so here it is duplicated:
 #' **a change to one must land in the other in the same session, verified.**
 #' @author Saiem Gilani
-#' @importFrom tibble as_tibble
 #' @importFrom janitor clean_names
 #' @family ESPN Basketball
 #' @export

--- a/R/espn_basketball_player_core.R
+++ b/R/espn_basketball_player_core.R
@@ -1,4 +1,7 @@
+#' **Project an ESPN core-v2 athlete record into a `player_core` row**
 #' @name espn_basketball_player_core
+NULL
+#' @rdname espn_basketball_player_core
 #' @aliases espn_basketball_player_core
 #' @title **Project an ESPN core-v2 athlete record into a `player_core` row**
 #' @description Turns one ESPN core-v2 `/athletes/{id}` payload into the single
@@ -85,13 +88,17 @@
 #'   )
 #'   espn_basketball_player_core(payload, athlete_id = 1966)
 #' }
-#'   **Twin.** `hoopR::espn_basketball_player_core()` is the identical
-#'   function for the men's leagues. The core-v2 athlete resource is the same
-#'   payload shape for nba/wnba/mbb/wbb, so the projection is league-agnostic
-#'   -- sdv-py implements it once and re-exports it per league. hoopR and
-#'   wehoop are independently published and neither depends on the other, so
-#'   here it is duplicated: **a change to one must land in the other in the
-#'   same session, verified.**
+#' @section Twin:
+#' `hoopR::espn_basketball_player_core()` is the identical function for the
+#' men's leagues. The core-v2 athlete resource is the same payload shape for
+#' nba/wnba/mbb/wbb, so the projection is league-agnostic -- sdv-py implements
+#' it once and re-exports it per league. hoopR and wehoop are independently
+#' published and neither depends on the other, so here it is duplicated:
+#' **a change to one must land in the other in the same session, verified.**
+#' @author Saiem Gilani
+#' @importFrom tibble as_tibble
+#' @importFrom janitor clean_names
+#' @family ESPN Basketball
 #' @export
 espn_basketball_player_core <- function(payload, athlete_id) {
   cols <- .player_core_cols()
@@ -152,7 +159,9 @@ espn_basketball_player_core <- function(payload, athlete_id) {
     active = .pc_lgl(payload[["active"]])
   )
 
-  tibble::as_tibble(row[cols])
+  tibble::as_tibble(row[cols]) %>%
+    janitor::clean_names() %>%
+    make_wehoop_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
 }
 
 #' The released column order. Order is part of the contract -- both pipelines
@@ -189,7 +198,12 @@ espn_basketball_player_core <- function(payload, athlete_id) {
     if (c %in% int_cols) integer() else if (c %in% dbl_cols) numeric() else if (c == "active") logical() else character()
   })
   names(proto) <- cols
-  tibble::as_tibble(proto)
+  # The empty path is finalized identically to the populated one, so a caller
+  # that chains on the result sees the same class and attributes whether or not
+  # the payload had anything in it.
+  tibble::as_tibble(proto) %>%
+    janitor::clean_names() %>%
+    make_wehoop_data("ESPN Basketball Player Core from ESPN.com", Sys.time())
 }
 
 #' A nested node, or an empty list when absent. Mirrors Python's

--- a/README.Rmd
+++ b/README.Rmd
@@ -106,7 +106,7 @@ For more information on the package and function reference, please see the  [**`
 [![X Follow](https://img.shields.io/twitter/follow/SportsDataverse?style=for-the-badge&logo=x&label=%40SportsDataverse
 )](https://x.com/SportsDataverse)
 
-[![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/wehoop.svg?color=eee&logo=github&style=for-the-badge&label=Star%20wehoop&maxAge=2592000)](https://github.com/sportsdataverse/wehoop/stargazers/)
+[![GitHub stars](https://img.shields.io/github/stars/sportsdataverse/wehoop.svg?color=eee&logo=github&style=for-the-badge&label=Star%20wehoop&maxAge=2592000)](https://github.com/sportsdataverse/wehoop/stargazers)
 
 
 # **Our Authors**

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Releases**](https://wehoop.sportsdataverse.org/news/index.html)
 Follow](https://img.shields.io/twitter/follow/SportsDataverse?style=for-the-badge&logo=x&label=%40SportsDataverse)](https://x.com/SportsDataverse)
 
 [![GitHub
-stars](https://img.shields.io/github/stars/sportsdataverse/wehoop.svg?color=eee&logo=github&style=for-the-badge&label=Star%20wehoop&maxAge=2592000)](https://github.com/sportsdataverse/wehoop/stargazers/)
+stars](https://img.shields.io/github/stars/sportsdataverse/wehoop.svg?color=eee&logo=github&style=for-the-badge&label=Star%20wehoop&maxAge=2592000)](https://github.com/sportsdataverse/wehoop/stargazers)
 
 # **Our Authors**
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -229,6 +229,7 @@ reference:
       - '`load_wnba_game_rosters_manifest`'
       - '`load_wnba_officials`'
       - '`load_wnba_officials_manifest`'
+      - '`load_wnba_player_core`'
       - '`update_wnba_db`'
   - subtitle: Women's College Basketball Data Functions
     desc: Functions exported by wehoop to access the wehoop-data repository's Women's College Basketball Data
@@ -251,6 +252,7 @@ reference:
       - '`load_wbb_game_rosters_manifest`'
       - '`load_wbb_officials`'
       - '`load_wbb_officials_manifest`'
+      - '`load_wbb_player_core`'
       - '`update_wbb_db`'
   - subtitle: WNBA Stats API Data Loaders
     desc: Functions exported by wehoop to access wehoop-wnba-stats-data WNBA Stats API artifacts
@@ -287,6 +289,7 @@ reference:
     desc: ESPN basketball endpoint family overview (WNBA + WBB)
     contents:
       - '`espn_basketball`'
+      - '`espn_basketball_player_core`'
   - subtitle: WBB -- Game data
     desc: Per-game endpoints for women's college basketball (play-by-play, box scores, rosters)
     contents:
@@ -562,6 +565,7 @@ reference:
       - '`check_status`'
       - '`csv_from_url`'
       - '`rds_from_url`'
+      - '`parquet_from_url`'
       - '`most_recent_wbb_season`'
       - '`most_recent_wnba_season`'
       - '`most_recent_wnba_stats_season`'

--- a/man/bart_wbb_game_schedule.Rd
+++ b/man/bart_wbb_game_schedule.Rd
@@ -17,7 +17,7 @@ columns, and \code{year}.
 }
 \description{
 \strong{Get the full women's game-by-game schedule and results for a season from
-\href{https://barttorvik.com/ncaaw}{barttorvik.com}.} Pulls the
+\href{https://barttorvik.com/ncaaw/}{barttorvik.com}.} Pulls the
 \verb{/ncaaw/\{year\}_super_sked.json} file (one row per game). No API key required.
 }
 \examples{

--- a/man/bart_wbb_ratings.Rd
+++ b/man/bart_wbb_ratings.Rd
@@ -17,7 +17,7 @@ columns, and \code{year}.
 }
 \description{
 \strong{Get women's college basketball T-Rank team ratings and adjusted
-efficiencies from \href{https://barttorvik.com/ncaaw}{barttorvik.com}.} Pulls the
+efficiencies from \href{https://barttorvik.com/ncaaw/}{barttorvik.com}.} Pulls the
 \verb{/ncaaw/\{year\}_team_results.csv} file (one row per team). No API key required.
 }
 \examples{

--- a/man/espn_basketball.Rd
+++ b/man/espn_basketball.Rd
@@ -54,5 +54,9 @@ per-call proxy overrides aren't supported. Use
 \code{https_proxy} env vars for proxy routing.
 }
 }
+\seealso{
+Other ESPN Basketball:
+\code{\link[=espn_basketball_player_core]{espn_basketball_player_core()}}
+}
 \concept{ESPN Basketball}
 \keyword{ESPN}

--- a/man/espn_basketball_player_core.Rd
+++ b/man/espn_basketball_player_core.Rd
@@ -85,3 +85,31 @@ against a golden fixture captured from that function; see
 \code{tests/testthat/fixtures/player_core/README.md} for provenance. Neither
 implementation is authoritative — a divergence is a review item.
 }
+\section{Twin}{
+
+\code{hoopR::espn_basketball_player_core()} is the identical function for the
+men's leagues. The core-v2 athlete resource is the same payload shape for
+nba/wnba/mbb/wbb, so the projection is league-agnostic -- sdv-py implements
+it once and re-exports it per league. hoopR and wehoop are independently
+published and neither depends on the other, so here it is duplicated:
+\strong{a change to one must land in the other in the same session, verified.}
+}
+
+\examples{
+\donttest{
+  payload <- list(
+    guid = "abc", fullName = "Jane Doe", jersey = "23",
+    position = list(id = "5", abbreviation = "G"),
+    team = list(`$ref` = "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2025/teams/22")
+  )
+  espn_basketball_player_core(payload, athlete_id = 1966)
+}
+}
+\seealso{
+Other ESPN Basketball:
+\code{\link{espn_basketball}}
+}
+\author{
+Saiem Gilani
+}
+\concept{ESPN Basketball}

--- a/man/espn_basketball_player_core.Rd
+++ b/man/espn_basketball_player_core.Rd
@@ -97,10 +97,16 @@ published and neither depends on the other, so here it is duplicated:
 
 \examples{
 \donttest{
+  # Split across lines to keep the Rd under the line-width limit; the
+  # core-v2 $ref URLs are long enough to be truncated in the PDF manual.
+  team_ref <- paste0(
+    "http://sports.core.api.espn.com/v2/sports/basketball/",
+    "leagues/wnba/seasons/2025/teams/22"
+  )
   payload <- list(
     guid = "abc", fullName = "Jane Doe", jersey = "23",
     position = list(id = "5", abbreviation = "G"),
-    team = list(`$ref` = "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2025/teams/22")
+    team = list(`$ref` = team_ref)
   )
   espn_basketball_player_core(payload, athlete_id = 1966)
 }

--- a/tests/testthat/test-espn_basketball_player_core.R
+++ b/tests/testthat/test-espn_basketball_player_core.R
@@ -96,7 +96,7 @@ test_that("espn_basketball_player_core() reproduces the sdv-py oracle", {
 
 test_that("espn_basketball_player_core() covers the branches the fixtures encode", {
   fx <- testthat::test_path("fixtures", "player_core")
-  read_one <- function(file, aid) {
+  .read_one <- function(file, aid) {
     espn_basketball_player_core(
       jsonlite::fromJSON(file.path(fx, file), simplifyVector = FALSE),
       athlete_id = aid
@@ -104,15 +104,15 @@ test_that("espn_basketball_player_core() covers the branches the fixtures encode
   }
 
   # wnba 1007 has no college node: college_id NA, not 0 and not an error.
-  expect_true(is.na(read_one("wnba_1007.json", 1007L)$college_id))
+  expect_true(is.na(.read_one("wnba_1007.json", 1007L)$college_id))
   # wnba 1002 is the fully-populated pro path.
-  full <- read_one("wnba_1002.json", 1002L)
+  full <- .read_one("wnba_1002.json", 1002L)
   expect_false(is.na(full$college_id))
   expect_false(is.na(full$draft_year))
   # wbb 10000 is the college case that the men's fixtures cannot reach: it has
   # NO college node yet still resolves a birth_country, because college payloads
   # carry birthCountry at the TOP LEVEL rather than nested under birthPlace.
-  college <- read_one("wbb_10000.json", 10000L)
+  college <- .read_one("wbb_10000.json", 10000L)
   expect_true(is.na(college$college_id))
   expect_equal(college$birth_country, "USA")
 })

--- a/tests/testthat/test-espn_basketball_player_core.R
+++ b/tests/testthat/test-espn_basketball_player_core.R
@@ -192,3 +192,27 @@ test_that("espn_basketball_player_core() keeps athlete_id an integer join key", 
   expect_equal(out$athlete_id, 1966L)
   expect_false(is.character(out$athlete_id))
 })
+
+test_that("espn_basketball_player_core() finalizes both paths as wehoop_data", {
+  # Without these assertions the suite passes even if make_wehoop_data() is deleted: the
+  # golden-master test compares values and column names, and neither changes
+  # when the class and attributes are dropped. The finalized contract was added
+  # in response to review, so it needs a test that fails when it regresses.
+  fx <- testthat::test_path("fixtures", "player_core")
+  populated <- espn_basketball_player_core(
+    jsonlite::fromJSON(file.path(fx, "wnba_1002.json"), simplifyVector = FALSE),
+    athlete_id = 1002L
+  )
+  empty <- espn_basketball_player_core(list(), athlete_id = 1L)
+
+  for (out in list(populated, empty)) {
+    expect_s3_class(out, "wehoop_data")
+    expect_equal(attr(out, "wehoop_type"),
+                 "ESPN Basketball Player Core from ESPN.com")
+    expect_s3_class(attr(out, "wehoop_timestamp"), "POSIXct")
+    # The finalizer must not disturb the 35-column contract it wraps.
+    expect_equal(ncol(out), 35L)
+  }
+  expect_equal(nrow(populated), 1L)
+  expect_equal(nrow(empty), 0L)
+})


### PR DESCRIPTION
Post-merge follow-up to #66, from the CodeRabbit review and a local R CMD
check + pkgdown check. Each finding was verified against current code first.

THE REAL BUG (CodeRabbit caught this; it was mine)

The Twin prose sat INSIDE the @examples block -- after the closing brace, but
with no new roxygen tag to end the section, so roxygen kept consuming it as
example content. The consequence was worse than invalid example code: the
generated Rd ended up with NO \examples section at all. hoopR had 1, wehoop
had 0, and the example silently vanished from the docs. R CMD check stayed
green precisely BECAUSE there was nothing left to run.

Fixed by promoting the prose to `@section Twin:`, which closes @examples
properly. The Rd now carries both the runnable example and the Twin note. The
same section is added to hoopR so the twins stay symmetric -- the note itself
says a change to one must land in the other.

ALSO ACCEPTED

  * Roxygen completeness: @name block with its NULL object, @rdname, @author,
    @importFrom, and @family ESPN Basketball (matching espn_basketball, the
    league-agnostic overview topic).
  * Finalize both return paths through janitor::clean_names() then
    make_wehoop_data(), populated and empty alike, per the package contract.
  * Test helper renamed read_one -> .read_one.

DECLINED

  * "%||% for null-safe defaults" (nitpick). These helpers do more than
    substitute for NULL -- .pc_chr/.pc_int/.pc_dbl/.pc_lgl also handle
    length-0, NA, and empty-string inputs and coerce with type validation.
    %||% only covers the NULL arm, so it would replace one branch of four and
    leave the rest, making them less uniform rather than more.

ALSO FIXED (found by the local gates)

  * pkgdown was broken: check_pkgdown() failed on load_wnba_player_core,
    load_wbb_player_core and parquet_from_url missing from the index. The
    first two are the same #199-era omission as hoopR. parquet_from_url is
    marked `@keywords Internal` -- capital I, which roxygen does not recognise
    (the keyword is case-sensitive), so it was never dropped from the index as
    intended. Indexed it beside csv_from_url/rds_from_url, which are both
    already listed; its absence was the anomaly. NOTE: five more functions in
    utils.R carry the same wrong-case keyword and are all deliberately indexed,
    so correcting their case would HIDE five documented functions -- left
    alone, flagged here.

  * .Rbuildignore was missing ^\.claude$ entirely (hoopR has it), so a local
    build swept in four stale agent worktrees and tripped BOTH a hidden-files
    NOTE and a non-portable-file-names NOTE. Added, along with the agent/tool
    dirs.

Verified: parity test 59/59, roxygen clean (0 warnings), check_pkgdown()
passes.

## Summary by Sourcery

Fix documentation and output contract issues around ESPN basketball player core while repairing the pkgdown reference index and build ignore configuration.

Bug Fixes:
- Restore the espn_basketball_player_core examples by moving the Twin prose into its own documentation section so it no longer suppresses the example block.
- Ensure espn_basketball_player_core always returns data finalized via clean_names() and make_wehoop_data() for both populated and empty payloads, matching the package contract.
- Add missing pkgdown reference entries for WNBA/WBB player_core loaders and parquet_from_url so they appear correctly in the reference index.
- Update .Rbuildignore to exclude Claude agent artifacts and related directories from package builds, preventing hidden/non-portable file name NOTES.

Enhancements:
- Enrich espn_basketball_player_core documentation with explicit roxygen metadata (name/rdname, author, imports, and ESPN Basketball family membership) and cross-link it from the espn_basketball overview topic.
- Align the empty espn_basketball_player_core path with the populated path so callers always see consistent classes and attributes on the result.
- Rename a player core test helper to .read_one to follow internal helper naming conventions.

Build:
- Adjust .Rbuildignore to filter out local agent worktrees and tools from source tarballs.

Documentation:
- Fix and extend pkgdown reference configuration to index ESPN basketball player core helpers and parquet_from_url alongside related utilities.
- Add a dedicated Twin documentation section for espn_basketball_player_core and link it within the ESPN Basketball topic family.

Tests:
- Update player core tests to use the renamed .read_one helper while preserving branch coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESPN basketball player data consistency, including standardized metadata, timestamps, naming, and output structure for populated and empty results.
  * Updated women’s basketball source links for more reliable navigation.

* **Documentation**
  * Expanded ESPN basketball helper documentation, examples, cross-references, and package documentation coverage.
  * Corrected repository and schedule links.

* **Chores**
  * Added exclusions for development tools, caches, logs, and raw data files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->